### PR TITLE
feat: Add automated stale and orphan branch management bot with Jenki…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,55 @@
+pipeline {
+    agent {
+        docker {
+            image 'python:3.12-slim'
+            args '-u root' // to allow pip installs if needed
+        }
+    }
+
+    environment {
+        GITHUB_TOKEN = credentials('GITHUB_PAT') // Jenkins credential ID
+    }
+
+    options {
+        timestamps()
+        disableConcurrentBuilds()
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                git url: 'https://github.com/Ram-Tech-Maestro/jenkins-branch-cleaner-bot.git', branch: 'main'
+            }
+        }
+
+        stage('Install Dependencies') {
+            steps {
+                sh '''
+                    python --version
+                    pip install --upgrade pip
+                    pip install -r requirements.txt
+                '''
+            }
+        }
+
+        stage('Run Cleanup Bot') {
+            steps {
+                sh '''
+                    python cleanup_bot.py
+                '''
+            }
+        }
+    }
+
+    post {
+        success {
+            echo '✅ Cleanup bot ran successfully.'
+        }
+        failure {
+            echo '❌ Cleanup bot failed. Check logs.'
+        }
+        always {
+            archiveArtifacts artifacts: 'stale_orphan_branches_report.md', onlyIfSuccessful: true
+        }
+    }
+}

--- a/cleanup_bot.py
+++ b/cleanup_bot.py
@@ -1,0 +1,115 @@
+import os
+import sys
+import yaml
+from datetime import datetime, timezone, timedelta
+from github import Github
+from github.GithubException import GithubException
+
+def load_config(config_path="config.yaml"):
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except Exception as e:
+        print(f"[ERROR] Failed to load {config_path}: {e}")
+        sys.exit(1)
+
+def main():
+    config = load_config()
+
+    github_token = os.getenv("GITHUB_TOKEN")
+    if not github_token:
+        print("[ERROR] GITHUB_TOKEN environment variable not set.")
+        sys.exit(1)
+
+    g = Github(github_token)
+
+    # Read from refactored config
+    repo_owner = config["repository"]["owner"]
+    repo_name = config["repository"]["name"]
+
+    cleanup_config = config["cleanup_bot"]
+    stale_days_threshold = cleanup_config.get("stale_days_threshold", 45)
+    grace_period_days = cleanup_config.get("grace_period_days", 7)
+    excluded_branches = cleanup_config.get("excluded_branches", ["main", "master", "develop"])
+    notification_issue_title = cleanup_config.get("notification_issue_title", "[BOT] Stale Branch Notification")
+    report_file = cleanup_config.get("log_file", "stale_orphan_branches_report.md")
+
+    repo = g.get_repo(f"{repo_owner}/{repo_name}")
+    print(f"[INFO] Connected to repository: {repo_owner}/{repo_name}")
+
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=stale_days_threshold)
+    stale_branches = []
+    orphan_branches = []
+
+    for branch in repo.get_branches():
+        branch_name = branch.name
+
+        # Skip excluded branches
+        if any([
+            branch_name == ex or (ex.endswith("/*") and branch_name.startswith(ex[:-2]))
+            for ex in excluded_branches
+        ]):
+            continue
+
+        try:
+            commits = repo.get_commits(sha=branch_name)
+            last_commit_date = commits[0].commit.committer.date
+
+            if last_commit_date < cutoff_date:
+                # Check for open PRs targeting this branch
+                try:
+                    open_prs = repo.get_pulls(state='open', base=branch_name)
+                    if open_prs.totalCount > 0:
+                        continue
+                except GithubException as e:
+                    print(f"[WARNING] Skipping PR check for {branch_name}: {e}")
+
+                # Check if the branch has been merged via PR
+                merged_prs = repo.get_pulls(state='closed', head=f"{repo_owner}:{branch_name}")
+                if any(pr.is_merged() for pr in merged_prs):
+                    continue
+
+                stale_branches.append({
+                    "branch": branch_name,
+                    "last_commit": last_commit_date.isoformat()
+                })
+
+            # Check if orphan (no open or closed PRs from this branch)
+            open_prs_head = repo.get_pulls(state='open', head=f"{repo_owner}:{branch_name}")
+            closed_prs_head = repo.get_pulls(state='closed', head=f"{repo_owner}:{branch_name}")
+            if open_prs_head.totalCount == 0 and closed_prs_head.totalCount == 0:
+                orphan_branches.append({
+                    "branch": branch_name,
+                    "last_commit": last_commit_date.isoformat()
+                })
+
+        except GithubException as e:
+            print(f"[WARNING] Skipping branch {branch_name}: {e}")
+            continue
+
+    # Write structured report
+    with open(report_file, "w", encoding="utf-8") as f:
+        f.write(f"# 🧹 Stale & Orphan Branches Report for `{repo_name}`\n\n")
+        f.write(f"_Generated: {datetime.now(timezone.utc).isoformat()}_\n\n")
+
+        if stale_branches:
+            f.write(f"## 🚩 Stale Branches (> {stale_days_threshold} days of inactivity)\n")
+            for sb in stale_branches:
+                f.write(f"- `{sb['branch']}` (Last commit: `{sb['last_commit']}`)\n")
+            f.write("\n")
+        else:
+            f.write("✅ No stale branches found.\n\n")
+
+        if orphan_branches:
+            f.write("## 🗃️ Orphan Branches (No PRs found)\n")
+            for ob in orphan_branches:
+                f.write(f"- `{ob['branch']}` (Last commit: `{ob['last_commit']}`)\n")
+            f.write("\n")
+        else:
+            f.write("✅ No orphan branches found.\n\n")
+
+    print(f"[INFO] Stale & orphan branches report written to `{report_file}`.")
+    print("[INFO] Cleanup analysis completed without deletion as requested.")
+
+if __name__ == "__main__":
+    main()

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,42 @@
+# ==========================================================
+# 🌿 Common Repository Configuration
+# ==========================================================
+repository:
+  owner: Ram-Tech-Maestro
+  name: branch-cleaner-test-repo
+  clone_url: https://github.com/Ram-Tech-Maestro/branch-cleaner-test-repo.git
+  base_branch: main
+
+# ==========================================================
+# ⚙️ Global Options
+# ==========================================================
+options:
+  dry_run: false      # true: simulate actions without push/write
+  log_level: INFO     # DEBUG | INFO | WARN | ERROR
+  timezone: Asia/Kolkata
+
+# ==========================================================
+# 🛠️ Test Branch Generator Bot Configuration
+#   Used by: generate_stale_branches_local.py
+# ==========================================================
+test_branch_generator:
+  stale_days_list:
+    - 60
+    - 90
+  orphan_branch_names:
+    - orphan-branch-1
+    - orphan-branch-2
+
+# ==========================================================
+# 🧹 Cleanup Bot Configuration
+#   Used by: cleanup_bot.py
+# ==========================================================
+cleanup_bot:
+  stale_days_threshold: 45                  # Days since last commit to mark as stale
+  grace_period_days: 7                      # Grace period before deletion (not auto-delete now, only logs)
+  excluded_branches:
+    - main
+    - dev
+    - release/*
+  notification_issue_title: "[BOT] Stale Branch Notification"
+  log_file: stale_orphan_branches_report.md

--- a/generate_stale_branches_local.py
+++ b/generate_stale_branches_local.py
@@ -1,0 +1,158 @@
+import os
+import subprocess
+import sys
+import yaml
+import shutil
+import stat
+from datetime import datetime, timedelta
+from pathlib import Path
+
+def load_config(config_path="config.yaml"):
+    with open(config_path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+def run(cmd, cwd=None, env=None, capture_output=True):
+    print(f"[CMD] {' '.join(cmd) if isinstance(cmd, list) else cmd}")
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE if capture_output else None,
+        stderr=subprocess.PIPE if capture_output else None,
+        text=True,
+        shell=isinstance(cmd, str)
+    )
+    if result.returncode != 0:
+        if capture_output:
+            print(f"[ERROR] Command failed:\n{result.stderr.strip()}")
+        else:
+            print(f"[ERROR] Command failed with return code {result.returncode}")
+        sys.exit(1)
+    return result.stdout.strip() if capture_output else ""
+
+def clone_repo(clone_url, target_dir):
+    if target_dir.exists():
+        print(f"[INFO] Repo already cloned at {target_dir}, pulling latest.")
+        run(["git", "fetch", "--all"], cwd=target_dir)
+        run(["git", "checkout", "main"], cwd=target_dir)
+        run(["git", "pull"], cwd=target_dir)
+    else:
+        print(f"[INFO] Cloning {clone_url} into {target_dir}")
+        run(["git", "clone", clone_url, str(target_dir)])
+
+def set_remote_url_with_token(repo_dir, remote_name, clone_url_with_token):
+    run(["git", "remote", "set-url", remote_name, clone_url_with_token], cwd=repo_dir)
+    print(f"[INFO] Updated remote {remote_name} to use token-authenticated URL.")
+
+def create_branch_and_backdated_commit(repo_dir, base_branch, new_branch, days_ago, dry_run=False):
+    run(["git", "checkout", base_branch], cwd=repo_dir)
+
+    branches_output = run(["git", "branch", "-a"], cwd=repo_dir)
+    if new_branch in branches_output:
+        print(f"[INFO] Branch {new_branch} already exists. Checking out.")
+        run(["git", "checkout", new_branch], cwd=repo_dir)
+    else:
+        print(f"[INFO] Creating and checking out {new_branch} from {base_branch}")
+        run(["git", "checkout", "-b", new_branch], cwd=repo_dir)
+
+    # Create or update dummy file
+    file_name = f"testfile_{new_branch}.txt"
+    file_path = repo_dir / file_name
+    with open(file_path, "a", encoding="utf-8") as f:
+        f.write(f"Update for {new_branch} at simulated {days_ago} days ago.\n")
+
+    # Stage the file
+    run(["git", "add", file_name], cwd=repo_dir)
+
+    # Backdate commit
+    backdate = datetime.now() - timedelta(days=days_ago)
+    backdate_str = backdate.strftime("%Y-%m-%dT%H:%M:%S")
+
+    env = os.environ.copy()
+    env["GIT_AUTHOR_DATE"] = backdate_str
+    env["GIT_COMMITTER_DATE"] = backdate_str
+
+    try:
+        run(["git", "commit", "-m", f"Update test file on {new_branch} simulating {days_ago} days ago"], cwd=repo_dir, env=env)
+    except SystemExit:
+        print(f"[INFO] No changes to commit on {new_branch}. Skipping commit.")
+
+    if dry_run:
+        print(f"[DRY-RUN] Would pull, rebase, and push branch {new_branch}.")
+        return
+
+    # Pull with rebase
+    try:
+        run(["git", "pull", "--rebase", "origin", new_branch], cwd=repo_dir)
+    except SystemExit:
+        print(f"[ERROR] Rebase failed on {new_branch}. Resolve manually if needed.")
+        sys.exit(1)
+
+    # Push updated branch
+    run(["git", "push", "origin", new_branch], cwd=repo_dir)
+    print(f"[SUCCESS] Pushed {new_branch} with backdated commit after rebase.")
+
+def handle_remove_readonly(func, path, exc_info):
+    if not os.access(path, os.W_OK):
+        os.chmod(path, stat.S_IWUSR)
+        func(path)
+    else:
+        raise
+
+def safe_remove_directory(path):
+    try:
+        shutil.rmtree(path, onerror=handle_remove_readonly)
+        print(f"[CLEANUP] Removed temporary repo directory: {path}")
+    except Exception as e:
+        print(f"[WARNING] Failed to remove {path}. Error: {e}")
+
+def main():
+    config = load_config()
+    github_token = os.getenv("GITHUB_TOKEN")
+    if not github_token:
+        print("[ERROR] GITHUB_TOKEN environment variable not set.")
+        sys.exit(1)
+
+    # Read using new structure
+    repo_config = config["repository"]
+    test_config = config["test_branch_generator"]
+    options_config = config["options"]
+
+    owner = repo_config["owner"]
+    repo_name = repo_config["name"]
+    repo_clone_url = repo_config["clone_url"]
+    base_branch = repo_config.get("base_branch", "main")
+
+    stale_days_list = test_config.get("stale_days_list", [60, 90])
+    orphan_branch_names = test_config.get("orphan_branch_names", [])
+    dry_run = options_config.get("dry_run", False)
+
+    # Inject token into HTTPS clone URL
+    if repo_clone_url.startswith("https://"):
+        repo_clone_url_with_token = repo_clone_url.replace(
+            "https://",
+            f"https://{github_token}:x-oauth-basic@"
+        )
+    else:
+        print("[ERROR] repo_clone_url must start with https://")
+        sys.exit(1)
+
+    repos_dir = Path.cwd() / "repos"
+    repos_dir.mkdir(exist_ok=True)
+    repo_dir = repos_dir / repo_name
+
+    clone_repo(repo_clone_url_with_token, repo_dir)
+    set_remote_url_with_token(repo_dir, "origin", repo_clone_url_with_token)
+
+    for days in stale_days_list:
+        branch_name = f"stale-{days}-days"
+        create_branch_and_backdated_commit(repo_dir, base_branch, branch_name, days, dry_run)
+
+    for ob_branch in orphan_branch_names:
+        create_branch_and_backdated_commit(repo_dir, base_branch, ob_branch, 10, dry_run)
+
+    safe_remove_directory(repo_dir)
+    print("[INFO] All branches created/updated with backdated commits and cleanup completed.")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyGithub
+PyYAML


### PR DESCRIPTION
feat: Add automated stale and orphan branch management bot with Jenkins pipeline

- Add `cleanup_bot.py` to analyze and log stale/orphan branches in GitHub repositories.
- Add `generate_stale_branches_local.py` for local test branch creation with backdated commits.
- Add `config.yaml` with structured configuration for repo management and cleanup bot settings.
- Add `Jenkinsfile` for enterprise-grade automation using Python Docker agent, securely using GitHub PAT.
- Include clear logging, error handling, and cleanup processes for consistent and maintainable operations.
- Enables fully automated stale/orphan branch visibility in CI pipelines, supporting scheduled or manual runs.

#maintenance #devops #automation
